### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # app-dev
 my first repository
+
+H2 Favorate series/movie : fast and furious "tokyo drift"
+
+*Sean Boswell (Lucas Black) always feels like an outsider, but he defines himself through his victories as a street racer. His hobby makes him unpopular with the authorities, so he goes to live with his father in Japan. Once there and even more alienated, he learns about an exciting, but dangerous, new style of the sport. The stakes are high when Sean takes on the local champion and falls for the man's girlfriend.*


### PR DESCRIPTION
The Fast and the Furious: Tokyo Drift is 1927 on the JustWatch Daily Streaming Charts today. The movie has moved down the charts by -131 places since yesterday. In the United States, it is currently more popular than Fences but less popular than The Park Maniac.